### PR TITLE
Drop Ember 3.28 support

### DIFF
--- a/.woodpecker/.scenarios.yml
+++ b/.woodpecker/.scenarios.yml
@@ -1,6 +1,5 @@
 matrix:
   scenario:
-    - ember-lts-3.28
     - ember-lts-4.12
 steps:
   - name: ${scenario}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ It works together with the backend service [adressenregister-fuzzy-search-servic
 
 ## Compatibility
 
-- Ember.js v3.28 or above
-- Ember CLI v3.28 or above
+- Ember.js v4.12 or above
+- Ember CLI v4.12 or above
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "ember-source": ">= 3.28.0"
+        "ember-source": ">= 4.12.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.95.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 3.28.0"
+    "ember-source": ">= 4.12.0"
   },
   "engines": {
     "node": ">= 18"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -7,16 +7,6 @@ module.exports = async function () {
   return {
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            '@ember/test-helpers': '~2.9.3',
-            'ember-qunit': '~6.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Ember v3 has been EOL for a very long time, and all our apps are on v4.12+ now.